### PR TITLE
Google Maps integration [do not merge]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,7 @@ docs/_build/
 
 # PyBuilder
 target/
+
+# Idea Projects
+datascience.iml
+.idea/*

--- a/polymaps/__init__.py
+++ b/polymaps/__init__.py
@@ -1,0 +1,14 @@
+from .main import Polymap
+from IPython.display import Javascript, display
+
+
+def load_ipython_extension(ipython):
+	# The `ipython` argument is the currently active `InteractiveShell`
+	# instance, which can be used in any way. This allows you to register
+	# new magics or aliases, for example.
+	ipython.register_magics(Polymap)
+	
+	# Loads the JS extension.
+	display(Javascript("""
+		IPython.load_extensions('datascience_polymaps_js/polymaps_views')
+		"""))

--- a/polymaps/main.py
+++ b/polymaps/main.py
@@ -1,0 +1,21 @@
+# This code can be put in any Python module, it does not require IPython
+# itself to be running already.  It only creates the magics subclass but
+# doesn't instantiate it yet.
+from __future__ import print_function
+from IPython.core.magic import Magics, magics_class, line_cell_magic
+
+# The class MUST call this class decorator at creation time
+@magics_class
+class Polymap(Magics):
+
+	@line_cell_magic
+	def polymap(self, line, cell=None):
+		"""Polymap works both as %polymap and as %%polymap"""
+		print("Full access to the main IPython object:", self.shell)
+		print("Variables in the user namespace:", list(self.shell.user_ns.keys()))
+		if cell is None:
+			print("Called as line magic")
+			return line
+		else:
+			print("Called as cell magic")
+			return line, cell

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ class PyTest(TestCommand):
 
 setup(
   name = 'datascience',
-  py_modules = ['datascience'],
+  py_modules = ['datascience', 'polymaps'],
   version = '0.1.1',
   install_requires = install_requires,
   tests_require = test_requires,


### PR DESCRIPTION
Current target behavior; feel free to comment below with objections/suggestions/comments.

Steps:
- [ ] 1. develop a simple, working JS script
- [ ] 2. develop Python wrapper for JS script
- [ ] 3. integrate Python wrapper with IPython

## Notebook

Using [IPython magic](http://ipython.org/ipython-doc/dev/config/extensions/index.html), load into a notebook:

```
load_ext datascience.polymap
```

To plot, use `polymap` magic

```
polymap  [flags[args]]  # line magic, exists only in this line
%%polymap  [flags[args]]  # cell magic, persists... across cells?
```

A sample invocation:
```
%%polymap
outline Los Angeles, CA
```

Options:
- [ ] `outline` -- using a polygon, outlines an area; accepts anything Google Maps can recognize
- [ ] `label` -- draws a dot and labels an area; accepts anything Google Maps can recognize
- [ ] `center` -- lat-long pair at the center of the map
- [ ] `zoom` -- zoom level

## Python Development

A Python script will generate JS to then output for the outside world.

**Polymap** -- main wrapper for a map
- [ ] `label_map` -- adds all MapPoints and labels to the map
- [ ] `outline_map` -- adds all MapRegions to the map
- [ ] `draw_map` -- draws a map using MapRegion and/or MapPoints
- [ ] `output` -- generate javascript

**MapRegion** -- a single polygon

**MapPoint** -- a single point, with a label and potentially display information

## Javascript Development

