### PR TITLE
Table fixes + optimizations

### DIFF
--- a/datascience/table.py
+++ b/datascience/table.py
@@ -13,6 +13,7 @@ import IPython
 
 import datascience.maps as maps
 
+
 class Table(collections.abc.Mapping):
     """A sequence of labeled columns.
 
@@ -239,7 +240,7 @@ class Table(collections.abc.Mapping):
             column = column == value
         return self.take(np.nonzero(column)[0])
 
-    def sort(self, column_or_label, ascending=False, distinct=False):
+    def sort(self, column_or_label, descending=False, distinct=False):
         """Return a Table of sorted rows by the values in a column."""
         column = self._get_column(column_or_label)
         if distinct:
@@ -247,7 +248,7 @@ class Table(collections.abc.Mapping):
         else:
             row_numbers = np.argsort(column, axis=0)
         assert (row_numbers < self.num_rows).all(), row_numbers
-        if not ascending:
+        if descending:
             row_numbers = np.array(row_numbers[::-1])
         return self.take(row_numbers)
 

--- a/datascience/table.py
+++ b/datascience/table.py
@@ -19,7 +19,7 @@ class Table(collections.abc.Mapping):
     >>> letters = ['a', 'b', 'c', 'z']
     >>> counts = [9, 3, 3, 1]
     >>> points = [1, 2, 2, 10]
-    >>> t = Table([('letter', letters), ('count', counts), ('points', points)])
+    >>> t = Table([letters, counts, points], ['letter', 'count', 'points'])
     >>> print(t)
     letter | count | points
     a      | 9     | 1

--- a/datascience/table.py
+++ b/datascience/table.py
@@ -149,13 +149,12 @@ class Table(collections.abc.Mapping):
         if isinstance(row_or_table, Table):
             table = row_or_table
             assert table.column_labels == self.column_labels
-            for row in list(row_or_table.rows):
-                self.append(row)
+            row, inc = list(row_or_table.columns), row_or_table.num_rows
         else:
-            row = row_or_table
-            for i, column in enumerate(self._columns):
-                self._columns[column] = np.append(self[column], row[i])
-        self._num_rows = self.num_rows + 1
+            row, inc = row_or_table, 1
+        for i, column in enumerate(self._columns):
+            self._columns[column] = np.append(self[column], row[i])
+        self._num_rows = self.num_rows + inc
         return self
 
     def relabel(self, column_label, new_label):

--- a/datascience/table.py
+++ b/datascience/table.py
@@ -368,10 +368,11 @@ class Table(collections.abc.Mapping):
         # build set of rows from rows that have values in both tables
         joined_rows = []
         for label, rows in self_rows.items():
-            if label in other_rows:
-                for row in rows:
-                    other_row = other_rows[label][0]
-                    joined_rows.append(row + other_row)
+            for row in rows:
+                other_row = other_rows[label][0]\
+                    if label in other_rows\
+                    else tuple([None]*other.num_rows)
+                joined_rows.append(row + other_row)
         if not joined_rows:
             return None
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -23,6 +23,13 @@ def table2():
 	return Table([points, names], ['points', 'names'])
 
 
+@pytest.fixture(scope='function')
+def table3():
+	"""Setup alphanumeric table, identical columns in diff order from first"""
+	letter, count, points = ['x', 'y', 'z'], [0, 54, 5], [3, 10, 24]
+	return Table([count, points, letter], ['count', 'points', 'letter'])
+
+
 @pytest.fixture(scope='module')
 def t():
 	"""Create one table for entire module"""
@@ -335,9 +342,33 @@ def test_append_table(table):
 	""")
 
 
-def test_append_bad_table(table, u):
-	with pytest.raises(AssertionError):
-		table.append(u)
+def test_append_different_table(table, u):
+	table.append(u)
+	assert_equal(table, """\
+	letter | count | points
+	a      | 9     | 1
+	b      | 3     | 2
+	c      | 3     | 2
+	z      | 1     | 10
+	None   | None  | 1
+	None   | None  | 2
+	None   | None  | 3
+	""")
+	
+
+def test_append_different_order(table, table3):
+	"""Tests append with same columns, diff order"""
+	table.append(table3)
+	assert_equal(table, """\
+	letter | count | points
+	a      | 9     | 1
+	b      | 3     | 2
+	c      | 3     | 2
+	z      | 1     | 10
+	x      | 0     | 3
+	y      | 54    | 10
+	z      | 5     | 24
+	""")
 
 
 def test_relabel():

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -192,6 +192,7 @@ def test_groups(t):
     10     | False | ['z']     | [1]   | [10]
 	""")
 
+
 def test_groups_collect(t):
 	t = t.copy()
 	t.append(('e', 12, 1, 12))
@@ -204,6 +205,7 @@ def test_groups_collect(t):
     2      | True  | 6
     10     | False | 1
 	""")
+
 
 def test_join(t, u):
 	"""Tests that join works, not destructive"""

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -221,6 +221,9 @@ def test_join(t, u):
 	points | letter | count | totals | names
 	1      | a      | 9     | 9      | one
 	2      | b      | 3     | 6      | two
+	2      | c      | 3     | 6      | two
+	10     | z      | 1     | 10     | None
+
 	""")
 	assert_equal(u, """\
 	points  | names
@@ -483,6 +486,8 @@ def test_join_basic(table, table2):
 	points | letter | count | totals | names
 	1      | a      | 9     | 9      | one
 	2      | b      | 3     | 6      | two
+	2      | c      | 3     | 6      | two
+	10     | z      | 1     | 10     | None
 	""")
 
 
@@ -490,12 +495,29 @@ def test_join_with_booleans(table, table2):
 	table['totals'] = table['points'] * table['count']
 	table['points'] = table['points'] > 1
 	table2['points'] = table2['points'] > 1
+	
+	assert_equal(table, """\
+	letter | count | points | totals
+	a      | 9     | False  | 9
+	b      | 3     | True   | 6
+	c      | 3     | True   | 6
+	z      | 1     | True   | 10
+	""")
+	
+	assert_equal(table2, """\
+	points | names
+	False  | one
+	True   | two
+	True   | three
+	""")
 
 	test = table.join('points', table2)
 	assert_equal(test, """\
 	points | letter | count | totals | names
 	False  | a      | 9     | 9      | one
 	True   | b      | 3     | 6      | two
+	True   | c      | 3     | 6      | two
+	True   | z      | 1     | 10     | two
 	""")
 
 
@@ -505,6 +527,7 @@ def test_join_with_self(table):
 	count | letter | points | letter_2 | points_2
 	1     | z      | 10     | z        | 10
 	3     | b      | 2      | b        | 2
+	3     | c      | 2      | b        | 2
 	9     | a      | 1      | a        | 1
 	""")
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -139,12 +139,12 @@ def test_sort(t):
 
 
 def test_sort_args(t):
-	test = t.sort('points', descending=False, distinct=True)
+	test = t.sort('points', descending=True, distinct=True)
 	assert_equal(test, """\
 	letter | count | points | totals
-	a      | 9     | 1      | 9
-	b      | 3     | 2      | 6
 	z      | 1     | 10     | 10
+	b      | 3     | 2      | 6
+	a      | 9     | 1      | 9
 	""")
 
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -39,7 +39,7 @@ def assert_equal(string1, string2):
 	string1, string2 = str(string1), str(string2)
 	whitespace = re.compile('\s')
 	purify = lambda s: whitespace.sub('', s)
-	assert purify(string1) == purify(string2), string1 + " != " + string2
+	assert purify(string1) == purify(string2), "\n%s\n!=\n%s" % (string1, string2)
 
 
 ############
@@ -139,12 +139,12 @@ def test_sort(t):
 
 
 def test_sort_args(t):
-	test = t.sort('points', decreasing=True, distinct=True)
+	test = t.sort('points', descending=False, distinct=True)
 	assert_equal(test, """\
 	letter | count | points | totals
-	z      | 1     | 10     | 10
-	b      | 3     | 2      | 6
 	a      | 9     | 1      | 9
+	b      | 3     | 2      | 6
+	z      | 1     | 10     | 10
 	""")
 
 


### PR DESCRIPTION
- [x] #2 `append` invoked only once per column when append table to table
- [x] #4 can append two tables with columns in different order (second table can have extra columns, but those will be ignored)
- [x] #22 fix join and join tests
- [x] #23 fixes sort tests
- [x] #24 fixes docstring for `Table`