### PR TITLE
Table fixes

### DIFF
--- a/datascience/table.py
+++ b/datascience/table.py
@@ -154,7 +154,8 @@ class Table(collections.abc.Mapping):
         return self
 
     def append(self, row_or_table):
-        """Append a row or all rows of a table with identical column names."""
+        """Append a row or all rows of a table. Rows or columns that do not
+        correspond will be padded with None values"""
         row, table, inc = row_or_table, row_or_table, 1
         if not row:
             return
@@ -266,7 +267,7 @@ class Table(collections.abc.Mapping):
 
         The grouped column will appear first in the result table.
         """
-        self = self._with_columns(self.columns) # Shallow self
+        self = self._with_columns(self.columns)  # Shallow self
         collect = _zero_on_type_error(collect)
 
         # Remove column used for grouping
@@ -702,6 +703,24 @@ class Table(collections.abc.Mapping):
 
         def __repr__(self):
             return '{0}({1})'.format(type(self).__name__, repr(self._table))
+
+
+class Q:
+    """advanced query manager for Table"""
+    
+    array = None
+    
+    def __init__(self, array):
+        """save numpy array"""
+        self.array = array
+    
+    def __and__(self, other):
+        """allows bitwise & operations"""
+        return np.logical_and(self.array, other.array)
+        
+    def __or__(self, other):
+        return np.logical_or(self.array, other.array)
+
 
 def _zero_on_type_error(column_fn):
     """Wrap a function on an np.ndarray to return 0 on a type error."""

--- a/datascience/table.py
+++ b/datascience/table.py
@@ -529,7 +529,7 @@ class Table(collections.abc.Mapping):
         if isinstance(value, (bool, np.bool_)):
             return str(value)
         try:
-            return '{:G}'.format(value)
+            return '{:n}'.format(value)
         except (ValueError, TypeError):
             return str(value)
 

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -558,3 +558,22 @@ def test_join_with_strings(table):
 ###########
 # Support #
 ###########
+
+
+def test_q_and(table):
+	"""Test that Q performs logical AND correctly"""
+	test = table.where(Q(table['letter'] < 'c') & Q(table['points'] > 1))
+	assert_equal(test, """\
+	letter | count | points
+	b      | 3     | 2
+	""")
+
+
+def test_q_or(table):
+	"""Test that Q performs logical OR correctly"""
+	test = table.where(Q(table['letter'] < 'b') | Q(table['points'] > 2))
+	assert_equal(test, """\
+	letter | count | points
+	a      | 9     | 1
+	z      | 1     | 10
+	""")

--- a/tests/test_table.py
+++ b/tests/test_table.py
@@ -547,7 +547,12 @@ def test_join_with_strings(table):
 # Export/Display #
 ##################
 
-
+def test_format_large_ints():
+	"""Tests that large ints are NOT formatted using scientific notation"""
+	assert_equal(
+		Table.format_value(123456789**5),
+		28679718602997181072337614380936720482949
+	)
 
 #############
 # Visualize #


### PR DESCRIPTION
- [x] #30 table `where`
- [x] #28 ints formatting

@papajohn How's this? Since we can't override Numpy operators.

```
t.where(Q(t['n'] != 2) & Q(t['m'] < 4))
t.where(Q(t['n'] == 6) | Q(t['m'] < 4))
```

After more browsing, discovered that [mongoengine](http://docs.mongoengine.org/en/latest/guide/querying.html#advanced-queries) (for MongoDB) uses this syntax. I assume that they have a good reason for it.