### PR TITLE
Add more documentation to hist and barh

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -667,7 +667,35 @@ class Table(collections.abc.MutableMapping):
         return t
 
     def hist(self, overlay=False, **vargs):
-        """Draw histograms of all columns."""
+        """Requires all columns in the table to contain numerical values only.
+        If the columns contain other types, a ValueError is raised.
+
+        Draw one histogram per column. If the overlay argument is True, a legend
+        containing the column name is shown on each histogram.
+
+        See http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.hist
+        for additional arguments that can be passed into vargs. These include:
+            bins, range, normed, cumulative, and orientation, to name a few.
+
+        >>> table
+        count | points
+        9     | 1
+        3     | 2
+        3     | 2
+        1     | 10
+
+        >>> table.hist()
+        <histogram of values in count>
+        <histogram of values in points>
+        """
+        # Check for non-numerical values and raise a ValueError if any found
+        # TODO(sam): Is a ValueError the right thing to raise?
+        for col in self:
+            if any(isinstance(cell, np.flexible) for cell in self[col]):
+                raise ValueError("The column '{0}' contains non-numerical "
+                    "values. A histogram cannot be drawn for this table."
+                    .format(col))
+
         n = len(self)
         colors = list(itertools.islice(itertools.cycle(('b', 'g', 'r')), n))
         if overlay:

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -617,7 +617,7 @@ class Table(collections.abc.MutableMapping):
             None
 
         Raises:
-            ValueError: The Table contained non-numerical values in columns
+            ValueError: The Table contains non-numerical values in columns
             other than `column_for_categories`
 
         >>> furniture_table
@@ -739,15 +739,26 @@ class Table(collections.abc.MutableMapping):
         return t
 
     def hist(self, overlay=False, **vargs):
-        """Requires all columns in the table to contain numerical values only.
+        """Plots one histogram for each column in the table.
+
+        Requires all columns in the table to contain numerical values only.
         If the columns contain other types, a ValueError is raised.
 
-        Draw one histogram per column. If the overlay argument is True, a legend
-        containing the column name is shown on each histogram.
+        Kwargs:
+            overlay (bool): If True, adds a legend to each of the plots showing
+                the column name being plotted.
 
-        See http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.hist
-        for additional arguments that can be passed into vargs. These include:
-        bins, range, normed, cumulative, and orientation, to name a few.
+            vargs: Additional arguments that get passed into :func:plt.hist.
+                See http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.hist
+                for additional arguments that can be passed into vargs. These
+                include: `bins`, `range`, `normed`, `cumulative`, and
+                `orientation`, to name a few.
+
+        Returns:
+            None
+
+        Raises:
+            ValueError: The Table contains non-numerical values
 
         >>> table
         count | points

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -745,8 +745,10 @@ class Table(collections.abc.MutableMapping):
         If the columns contain other types, a ValueError is raised.
 
         Kwargs:
-            overlay (bool): If True, adds a legend to each of the plots showing
-                the column name being plotted.
+            overlay (bool): If True, plots 1 chart with all the histograms
+                overlaid on top of each other (instead of the default behavior of
+                one histogram for each column in the table). Also adds a legend
+                that matches each bar color to its column.
 
             vargs: Additional arguments that get passed into :func:plt.hist.
                 See http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.hist


### PR DESCRIPTION
Also makes `Table.hist` and `Table.barh` throw a more helpful error message when the
Table contains invalid values (`np.flexible`, which includes strings).
Before, the method raised an error about not being able to operate on
"flexible types", which is not extremely helpful without knowledge of
numpy types.

Starts to address #50.

Travis tests are failing because of a long-standing issue with the date formatter.