### PR TITLE
Add Table.split method

### DIFF
--- a/docs/tables.rst
+++ b/docs/tables.rst
@@ -65,6 +65,7 @@ Transformation (creates a new table)
     Table.stats
     Table.percentile
     Table.sample
+    Table.split
 
 Exporting / Displaying
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -663,6 +663,23 @@ def test_sample_weights_with_none_k(table):
         assert len(set(u.rows)) == len(u.rows)
         i += 1
 
+def test_split_basic(table):
+    """Test that table.split works."""
+    table.split(3)
+
+def test_split_lengths(table):
+    """Test that table.split outputs tables with the right number of rows."""
+    sampled, rest = table.split(3)
+    assert sampled.num_rows == 3
+    assert rest.num_rows == table.num_rows - 3
+
+def test_split_k_vals(table):
+    """Test that invalid k values for table.split raises an error."""
+    with pytest.raises(ValueError):
+        table.split(0)
+    with pytest.raises(ValueError):
+        table.split(table.num_rows)
+
 #############
 # Visualize #
 #############


### PR DESCRIPTION
Also fixes up docstring for `Table.percentile` and renames the previous
`_split` method to `_split_by_column`