### PR TITLE
Add notes on Zenhub usage and workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,50 @@ python setup.py test
 The recommended environment for installation and tests is the
 [Anaconda Python3 distribution](http://continuum.io/downloads#py34)
 
-If you encounter an `Image not found` error on **Mac OSX**, you may need an [XQuartz upgrade](http://xquartz.macosforge.org/landing/).
+If you encounter an `Image not found` error on **Mac OSX**, you may need an
+[XQuartz upgrade](http://xquartz.macosforge.org/landing/).
+
+## Using Zenhub
+
+We use [Zenhub](https://www.zenhub.io/) to organize development on this library.
+To get started, go ahead and install the [Zenhub Chrome Extension][zenhub-extension].
+
+[zenhub-extension]: https://chrome.google.com/webstore/detail/zenhub-for-github/ogcgkffhplmphkaahpmffcafajaocjbd?hl=en-US
+
+Then navigate to [the issue board](#boards) or press `b`. You'll see a screen
+that looks something like this:
+
+![screenshot 2015-09-24 23 03 57](https://cloud.githubusercontent.com/assets/2468904/10094128/ddc05b92-6310-11e5-9a23-d51216370e89.png)
+
+- **New Issues** are issues that are just created and haven't been prioritized.
+- **Backlogged** issues are issues that are not high priority, like nice-to-have
+features.
+- **To Do** issues are high priority and should get done ASAP, such as
+breaking bugs or functionality that we need to lecture on soon.
+- Once someone has been assigned to an issue, that issue should be moved into
+the **In Progress** column.
+- When the task is complete, we close the related issue.
+
+### Example Workflow
+
+1. John creates an issue called "Everything is breaking". It goes into the New
+Issues pipeline at first.
+2. This issue is important, so John immediately moves it into the To Do
+pipeline. Since he has to go lecture for 61A, he doesn't assign it to himself
+right away.
+3. Sam sees the issue, assigns himself to it, and moves it into the In Progress
+pipeline.
+4. After everything is fixed, Sam closes the issue.
+
+Here's another example.
+
+1. Ani creates an issue asking for beautiful histograms. Like before, it goes
+into the New Issues pipeline.
+2. John decides that the issue is not as high priority right now because other
+things are breaking, so he moves it into the Backlog pipeline.
+3. When he has some more time, John assigns himself the issue and moves it into
+the In Progress pipeline.
+4. Once the issue is finished, he closes the issue.
 
 ## Publishing
 


### PR DESCRIPTION
Hopefully this will help us manage and prioritize our issues better!
Later on we can add some more documentation on how to use it with
multiple repos.

See https://github.com/dsten/datascience/tree/zenhub-usage#using-zenhub for an easier-to-read version of the notes.

@papajohn Can you look it over and maybe even take a look at the board for this repo?