### PR TITLE
Provide new minimal representation for row

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1316,17 +1316,17 @@ class Table(collections.abc.MutableMapping):
                 self._labels = labels
 
                 class Row(tuple):
-                    _table = self._table
+                    __table = self._table
 
                     def __getattr__(self, column_label):
-                        return self[self._table.column_index(column_label)]
+                        return self[self.__table.column_index(column_label)]
 
                     def __repr__(self):
                         return 'Row({})'.format(', '.join('{}={}'.format(
-                            self._table.column_labels[i], v.__repr__()) for i, v in enumerate(self)))
+                            self.__table.column_labels[i], v.__repr__()) for i, v in enumerate(self)))
 
                     def asdict(self):
-                        return collections.OrderedDict(zip(self._table.column_labels, self))
+                        return collections.OrderedDict(zip(self.__table.column_labels, self))
 
                 self._row = Row
 

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -581,7 +581,7 @@ class Table(collections.abc.MutableMapping):
         """
         rows, column_labels = [], column_labels or self.column_labels
         for row in self.rows:
-            [rows.append((getattr(row, key), k, v)) for k, v in row._asdict().items()
+            [rows.append((getattr(row, key), k, v)) for k, v in row.asdict().items()
              if k != key and k in column_labels]
         return Table.from_rows(rows, [key, 'column', 'value'])
 
@@ -1314,8 +1314,23 @@ class Table(collections.abc.MutableMapping):
             labels = tuple(self._table.column_labels)
             if labels != self._labels:
                 self._labels = labels
-                self._row = collections.namedtuple('Row', labels, rename=True)
-            return self._row(*[c[i] for c in self._table._columns.values()])
+
+                class Row(tuple):
+                    _table = self._table
+
+                    def __getattr__(self, column_label):
+                        return self[self._table.column_index(column_label)]
+
+                    def __repr__(self):
+                        return 'Row({})'.format(', '.join('{}={}'.format(
+                            self._table.column_labels[i], v.__repr__()) for i, v in enumerate(self)))
+
+                    def asdict(self):
+                        return collections.OrderedDict(zip(self._table.column_labels, self))
+
+                self._row = Row
+
+            return self._row([c[i] for c in self._table._columns.values()])
 
         def __len__(self):
             return self._table.num_rows


### PR DESCRIPTION
A row was earlier represented as a namedtuple. But this resulted in
the restriction that a table could not have more than 255 columns
(see http://stackoverflow.com/questions/18550270/any-way-to-bypass-namedtuple-255-arguments-limitation).

The new representation is a subclass of tuple which still
approximately provides access to column labels and has the same
representation. Additionally, column values can be accessed as
attributes and a mapping from column label to values can be obtained
using the asdict() method. Other behavior can be filled in as
required.