### PR TITLE
Use __all__ to specify exposed API

### DIFF
--- a/datascience/formats.py
+++ b/datascience/formats.py
@@ -1,5 +1,9 @@
 """String formatting for table entries."""
 
+__all__ = ['default_formatter', 'Formatter', 'NumberFormatter',
+           'CurrencyFormatter', 'DateFormatter', 'PercentFormatter']
+
+
 import numpy as np
 
 from datetime import datetime, timezone

--- a/datascience/maps.py
+++ b/datascience/maps.py
@@ -1,5 +1,8 @@
 """Draw maps using folium."""
 
+__all__ = ['Map', 'Marker', 'Circle', 'Region']
+
+
 import IPython.display
 import folium
 import pandas

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -829,10 +829,10 @@ class Table(collections.abc.MutableMapping):
             " | ".join(map(str, self.column_labels)))
 
     def __str__(self):
-        return self.as_text(self.max_str_rows)
+        return self._as_text(self.max_str_rows)
 
     def _repr_html_(self):
-        return self.as_html(self.max_str_rows)
+        return self._as_html(self.max_str_rows)
 
     def show(self, max_rows=0):
         """Display the table."""
@@ -840,7 +840,7 @@ class Table(collections.abc.MutableMapping):
 
     max_str_rows = 10
 
-    def as_text(self, max_rows=0, sep=" | "):
+    def _as_text(self, max_rows=0, sep=" | "):
         """Format table as text."""
         if not max_rows or max_rows > self.num_rows:
             max_rows = self.num_rows
@@ -856,7 +856,7 @@ class Table(collections.abc.MutableMapping):
             lines.append('... ({} rows omitted)'.format(omitted))
         return '\n'.join([line.rstrip() for line in lines])
 
-    def as_html(self, max_rows=0):
+    def _as_html(self, max_rows=0):
         """Format table as HTML."""
         if not max_rows or max_rows > self.num_rows:
             max_rows = self.num_rows

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1,5 +1,8 @@
 """Tables as ordered dictionaries of Numpy arrays."""
 
+__all__ = ['Table', 'Q']
+
+
 import collections
 import collections.abc
 import functools

--- a/datascience/util.py
+++ b/datascience/util.py
@@ -1,5 +1,8 @@
 """Utility functions"""
 
+__all__ = ['percentile']
+
+
 import numpy as np
 
 def percentile(p, arr=None):

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -2,6 +2,7 @@ from datascience import *
 from unittest.mock import MagicMock, patch
 import pytest
 import copy
+import json
 from IPython.display import HTML
 
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -1,5 +1,6 @@
 import re
 import pytest
+import numpy as np
 from numpy.testing import assert_array_equal
 from datascience import *
 


### PR DESCRIPTION
Only expose implemented API so that introspection can be used in IPython to discover the module content.