### PR TITLE
Import datascience as ds

### DIFF
--- a/tests/test_formats.py
+++ b/tests/test_formats.py
@@ -1,7 +1,7 @@
 import collections.abc
 import pytest
 import re
-from datascience import *
+import datascience as ds
 
 
 def assert_equal(string1, string2):
@@ -12,7 +12,7 @@ def assert_equal(string1, string2):
 
 
 def test_default_format():
-    fmt = default_formatter.format_value
+    fmt = ds.default_formatter.format_value
     assert_equal(fmt(1.23456789), '1.23457')
     assert_equal(fmt(123456789), '123456789')
     assert_equal(fmt(123456789**5), '28679718602997181072337614380936720482949')
@@ -24,10 +24,10 @@ def test_default_format():
 
 
 def test_number_format():
-    for fmt in [NumberFormatter(2), NumberFormatter]:
+    for fmt in [ds.NumberFormatter(2), ds.NumberFormatter]:
         us = ['1,000', '12,000']
         vs = ['1,000', '12,000.346']
-        t = Table([us, vs], ['u', 'v'])
+        t = ds.Table([us, vs], ['u', 'v'])
         t.set_format(['u', 'v'], fmt)
         assert_equal(t, """
         u      | v
@@ -38,8 +38,8 @@ def test_number_format():
 
 def test_currency_format():
     vs = ['$60', '$162.5']
-    t = Table([vs, vs, vs], ['num1', 'num2', 'str'])
-    t.set_format(['num1', 'num2'], CurrencyFormatter('$'))
+    t = ds.Table([vs, vs, vs], ['num1', 'num2', 'str'])
+    t.set_format(['num1', 'num2'], ds.CurrencyFormatter('$'))
     assert_equal(t, """
     num1    | num2    | str
     $60.00  | $60.00  | $60
@@ -59,15 +59,15 @@ def test_currency_format():
 
 def test_date_format():
     vs = ['2015-07-01 22:39:44.900351']
-    t = Table([vs], ['time'])
-    t.set_format('time', DateFormatter("%Y-%m-%d %H:%M:%S.%f"))
+    t = ds.Table([vs], ['time'])
+    t.set_format('time', ds.DateFormatter("%Y-%m-%d %H:%M:%S.%f"))
     assert isinstance(t['time'][0], float)
 
 
 def test_percent_formatter():
     vs = [0.1, 0.11111, 0.199999, 10]
-    t = Table([vs], ['percent'])
-    t.set_format('percent', PercentFormatter(1))
+    t = ds.Table([vs], ['percent'])
+    t.set_format('percent', ds.PercentFormatter(1))
     assert_equal(t, """
     percent
     10.0%

--- a/tests/test_maps.py
+++ b/tests/test_maps.py
@@ -1,14 +1,16 @@
-from datascience import *
 from unittest.mock import MagicMock, patch
 import pytest
 import copy
+import json
 from IPython.display import HTML
+
+import datascience as ds
 
 
 @pytest.fixture(scope='function')
 def states():
     """Read a map of US states."""
-    return Map.read_geojson('tests/us-states.json')
+    return ds.Map.read_geojson('tests/us-states.json')
 
 
 ############
@@ -30,28 +32,28 @@ def test_setup_map():
         'height': 500,
         'features': [],
     }
-    Map(**kwargs).show()
+    ds.Map(**kwargs).show()
 
 
 def test_map_marker_and_region(states):
     """ Tests that a Map can contain a Marker and/or Region. """
-    marker = Marker(51.514, -0.132)
-    Map(marker).show()
-    Map([marker]).show()
+    marker = ds.Marker(51.514, -0.132)
+    ds.Map(marker).show()
+    ds.Map([marker]).show()
     region = states['CA']
-    Map(region).show()
-    Map([region]).show()
-    Map([marker, region]).show()
+    ds.Map(region).show()
+    ds.Map([region]).show()
+    ds.Map([marker, region]).show()
 
 
 ##########
-# Marker #
+# ds.Marker #
 ##########
 
 
 def test_marker_html():
     """ Tests that a Marker can be rendered. """
-    Marker(51.514, -0.132).show()
+    ds.Marker(51.514, -0.132).show()
 
 
 def test_marker_map():
@@ -60,10 +62,10 @@ def test_marker_map():
     lons = [-1, -2, -3]
     labels = ['A', 'B', 'C']
     colors = ['blue', 'red', 'green']
-    Marker.map(lats, lons).show()
-    Marker.map(lats, lons, labels).show()
-    Marker.map(lats, lons, labels, colors).show()
-    Marker.map(lats, lons, colors=colors).show()
+    ds.Marker.map(lats, lons).show()
+    ds.Marker.map(lats, lons, labels).show()
+    ds.Marker.map(lats, lons, labels, colors).show()
+    ds.Marker.map(lats, lons, colors=colors).show()
 
 
 def test_marker_map_table():
@@ -71,16 +73,16 @@ def test_marker_map_table():
     lats = [51, 52, 53]
     lons = [-1, -2, -3]
     labels = ['A', 'B', 'C']
-    t = Table([lats, lons, labels], ['A', 'B', 'C'])
-    Marker.map_table(t).show()
+    t = ds.Table([lats, lons, labels], ['A', 'B', 'C'])
+    ds.Marker.map_table(t).show()
     colors = ['red', 'green', 'yellow']
     t['colors'] = colors
-    Marker.map_table(t).show()
+    ds.Marker.map_table(t).show()
 
 
 def test_circle_html():
     """ Tests that a Circle can be rendered. """
-    Circle(51.514, -0.132).show()
+    ds.Circle(51.514, -0.132).show()
 
 
 def test_circle_map():
@@ -88,8 +90,8 @@ def test_circle_map():
     lats = [51, 52, 53]
     lons = [-1, -2, -3]
     labels = ['A', 'B', 'C']
-    Circle.map(lats, lons).show()
-    Circle.map(lats, lons, labels).show()
+    ds.Circle.map(lats, lons).show()
+    ds.Circle.map(lats, lons, labels).show()
 
 
 ##########
@@ -115,8 +117,8 @@ def test_geojson(states):
 
 def test_bounds():
     """ Tests that generated bounds are correct """
-    points = [Marker(0, 0), Marker(-89.9, 180), Marker(90, -180)]
-    bounds = Map(points)._autobounds()
+    points = [ds.Marker(0, 0), ds.Marker(-89.9, 180), ds.Marker(90, -180)]
+    bounds = ds.Map(points)._autobounds()
     assert bounds['max_lat'] == 90
     assert bounds['min_lat'] == -89.9
     assert bounds['max_lon'] == 180
@@ -125,8 +127,8 @@ def test_bounds():
 
 def test_bounds_limits():
     """ Tests that too-large lats and lons are truncated to real bounds. """
-    points = [Marker(0, 0), Marker(-190, 280), Marker(190, -280)]
-    bounds = Map(points)._autobounds()
+    points = [ds.Marker(0, 0), ds.Marker(-190, 280), ds.Marker(190, -280)]
+    bounds = ds.Map(points)._autobounds()
     assert bounds['max_lat'] == 90
     assert bounds['min_lat'] == -90
     assert bounds['max_lon'] == 180
@@ -140,17 +142,17 @@ def test_bounds_limits():
 
 def test_color_table(states):
     """ Tests that color can take a Table. """
-    data = Table.read_table('tests/us-unemployment.csv')
+    data = ds.Table.read_table('tests/us-unemployment.csv')
     states.color(data).show()
 
 
 def test_color_dict(states):
     """ Tests that color can take a dict. """
-    data = Table.read_table('tests/us-unemployment.csv')
+    data = ds.Table.read_table('tests/us-unemployment.csv')
     states.color(dict(zip(*data.columns))).show()
 
 
 def test_color_values_and_ids(states):
     """ Tests that color can take values and ids. """
-    data = Table.read_table('tests/us-unemployment.csv')
+    data = ds.Table.read_table('tests/us-unemployment.csv')
     states.color(data['Unemployment'], data['State']).show()

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -1,16 +1,17 @@
 import pytest
 
-from datascience import *
+import datascience as ds
+
 
 def test_percentile():
-    assert percentile(0, [1, 3, 5, 9]) == 1
-    assert percentile(33, [1, 3, 5, 9]) == 3
-    assert percentile(34, [1, 3, 5, 9]) == 5
-    assert percentile(66, [1, 3, 5, 9]) == 5
-    assert percentile(67, [1, 3, 5, 9]) == 9
+    assert ds.percentile(0, [1, 3, 5, 9]) == 1
+    assert ds.percentile(33, [1, 3, 5, 9]) == 3
+    assert ds.percentile(34, [1, 3, 5, 9]) == 5
+    assert ds.percentile(66, [1, 3, 5, 9]) == 5
+    assert ds.percentile(67, [1, 3, 5, 9]) == 9
 
-    f1 = percentile(67)
+    f1 = ds.percentile(67)
     assert f1([1, 3, 5, 9]) == 9
 
-    f2 = percentile(66)
+    f2 = ds.percentile(66)
     assert f2([1, 3, 5, 9]) == 5


### PR DESCRIPTION
It is considered bad practice to do "from my_library import *".  This PR uses a more standard convention:

```
import datascience as ds
ds.Table(...)
```