### PR TITLE
Add row slicing

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -148,7 +148,11 @@ class Table(collections.abc.MutableMapping):
     #################
 
     def __getitem__(self, label):
-        return self.values(label)
+        if isinstance(label, slice) or hasattr(label, '__index__'):
+            return self._with_columns(column[label]
+                                      for column in self._columns.values())
+        else:
+            return self.values(label)
 
     def __setitem__(self, label, values):
         self.append_column(label, values)

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -749,3 +749,13 @@ def test_q_chaining(table):
     letter | count | points
     a      | 9     | 1
     """)
+
+def test_row_slicing(table):
+    t = table[:2]
+    assert_equal(t.column_labels, ('letter', 'count', 'points'))
+    assert_array_equal(t.columns[0], ['a', 'b'])
+    assert_array_equal(t.columns[1], [9, 3])
+    assert_array_equal(t.columns[2], [1, 2])
+
+    t_row = table[-1]
+    assert_equal(len(t_row.rows), 1)


### PR DESCRIPTION
This lets Tables behave similar to other Python containers, such that:

```
In [1]: import datascience as ds

In [2]: t = ds.Table((['a','b','c','d'], [1, 2, 3, 4]), ('names', 'counts'))

In [3]: print(t[:2])
names | counts
a     | 1
b     | 2

In [4]: print(t[-1])
names | counts
d     | 4

In [5]: print(t[1:-1])
names | counts
b     | 2
c     | 3

```