### PR TITLE
Add classmethods for creating empty tables and tables from a dict of column labels to column values

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -30,7 +30,7 @@ class Table(collections.abc.MutableMapping):
     ##########
 
     def __init__(self, columns=None, labels=None,
-            formatter=_formats.default_formatter):
+                 formatter=_formats.default_formatter):
         """Create a table from a list of column values or dictionary of
         sequences.
 
@@ -45,23 +45,16 @@ class Table(collections.abc.MutableMapping):
         c      | 3     | 2
         z      | 1     | 10
 
-        For other ways to initialize a table, see :func:`Table.from_rows`,
-        :func:`Table.from_records`, and :func:`Table.read_table`.
+        For other ways to initialize a table, see ;func;`Table.empty`,
+        :func:`Table.from_rows`, :func:`Table.from_records`,
+        :func:`Table.read_table`, and :func:`Table.from_columns_dict`.
 
         Kwargs:
-            columns (None, list, or dict): If ``None``, an empty table is
-                created.
-
-                If a list, each element in ``columns`` is another list
+            columns (list): A list in which each element is another list
                 containing the values for a column in the order the columns
                 appear in ``labels``.
 
-                If a dict, each key is a label of a column; each values is the
-                column's values as a list.
-
-            labels (list): A list of column labels. Must be specified if
-                ``columns`` is a list, and must be ``None`` if ``columns`` is a
-                dict.
+            labels (list): A list of column labels.
 
             formatter (Formatter): An instance of :class:`Formatter` that
                 formats the columns' values.
@@ -82,13 +75,8 @@ class Table(collections.abc.MutableMapping):
         self.formatter = formatter
 
         # Ensure inputs are properly formed
-        if not columns:
-            assert not labels, 'labels but no columns'
-            columns, labels = [], []
-        if isinstance(columns, collections.abc.Mapping):
-            assert labels is None, 'labels must be None if columns has labels'
-            columns, labels = columns.values(), columns.keys()
-        assert labels is not None, 'Labels are required'
+        columns = columns if columns is not None else []
+        labels = labels if labels is not None else []
         assert len(labels) == len(columns), 'label/column number mismatch'
 
         self._num_rows = 0 if len(columns) is 0 else len(columns[0])
@@ -96,6 +84,11 @@ class Table(collections.abc.MutableMapping):
         # Add each column to table
         for column, label in zip(columns, labels):
             self[label] = column
+
+    @classmethod
+    def empty(cls):
+        """Create an empty table."""
+        return cls()
 
     @classmethod
     def from_rows(cls, rows, column_labels):
@@ -109,6 +102,11 @@ class Table(collections.abc.MutableMapping):
             return cls()
         labels = sorted(list(records[0].keys()))
         return cls([[rec[label] for rec in records] for label in labels], labels)
+
+    @classmethod
+    def from_columns_dict(cls, columns):
+        """Create a table from a mapping of column labels to column values."""
+        return cls(columns.values(), columns.keys())
 
     @classmethod
     def read_table(cls, filepath_or_buffer, *args, **vargs):

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -45,7 +45,7 @@ class Table(collections.abc.MutableMapping):
         c      | 3     | 2
         z      | 1     | 10
 
-        For other ways to initialize a table, see ;func;`Table.empty`,
+        For other ways to initialize a table, see :func:`Table.empty`,
         :func:`Table.from_rows`, :func:`Table.from_records`,
         :func:`Table.read_table`, and :func:`Table.from_columns_dict`.
 

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -31,8 +31,7 @@ class Table(collections.abc.MutableMapping):
 
     def __init__(self, columns=None, labels=None,
                  formatter=_formats.default_formatter):
-        """Create a table from a list of column values or dictionary of
-        sequences.
+        """Create a table from a list of column values.
 
         >>> letters = ['a', 'b', 'c', 'z']
         >>> counts = [9, 3, 3, 1]
@@ -49,14 +48,14 @@ class Table(collections.abc.MutableMapping):
         :func:`Table.from_rows`, :func:`Table.from_records`,
         :func:`Table.read_table`, and :func:`Table.from_columns_dict`.
 
-        Kwargs:
-            columns (list): A list in which each element is another list
+        Args:
+            ``columns`` (list): A list in which each element is another list
                 containing the values for a column in the order the columns
                 appear in ``labels``.
 
-            labels (list): A list of column labels.
+            ``labels`` (list): A list of column labels.
 
-            formatter (Formatter): An instance of :class:`Formatter` that
+            ``formatter`` (Formatter): An instance of :class:`Formatter` that
                 formats the columns' values.
 
         Returns:
@@ -64,9 +63,7 @@ class Table(collections.abc.MutableMapping):
 
         Raises:
             AssertionError:
-                - ``labels`` is specified but ``columns`` is not.
-                - ``columns`` is a dict but ``labels`` are specified.
-                - ``columns`` is a list but ``labels`` are not specified.
+                - ``labels`` is specified but ``columns`` is not and vice-versa.
                 - The length of ``labels`` and the length of ``columns`` are
                   unequal.
         """
@@ -87,7 +84,22 @@ class Table(collections.abc.MutableMapping):
 
     @classmethod
     def empty(cls, column_labels=None):
-        """Create an empty table."""
+        """Create an empty table. Column labels are optional
+
+        >>> t = Table.empty(['x', 'y'])
+        >>> print(t.append((2, 3)))
+        x    | y
+        2    | 3
+
+        Args:
+            ``column_labels`` (None or list): If ``None``, a table with 0
+                columns is created.
+                If a list, each element is a column label in a table with
+                0 rows.
+
+        Returns:
+            A new instance of ``Table``.
+        """
         if column_labels is None:
             return cls()
         values = [[] for label in column_labels]
@@ -108,7 +120,22 @@ class Table(collections.abc.MutableMapping):
 
     @classmethod
     def from_columns_dict(cls, columns):
-        """Create a table from a mapping of column labels to column values."""
+        """Create a table from a mapping of column labels to column values.
+
+        >>> from collections import OrderedDict
+        >>> columns = OrderedDict()
+        >>> columns['letter'] = ['a', 'b', 'c', 'z']
+        >>> columns['count'] = [9, 3, 3, 1]
+        >>> columns['points'] = [1, 2, 2, 10]
+        >>> t = Table.from_columns_dict(columns)
+        >>> print(t)
+        letter | count | points
+        a      | 9     | 1
+        b      | 3     | 2
+        c      | 3     | 2
+        z      | 1     | 10
+
+        """
         return cls(list(columns.values()), columns.keys())
 
     @classmethod

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -86,9 +86,12 @@ class Table(collections.abc.MutableMapping):
             self[label] = column
 
     @classmethod
-    def empty(cls):
+    def empty(cls, column_labels=None):
         """Create an empty table."""
-        return cls()
+        if column_labels is None:
+            return cls()
+        values = [[] for label in column_labels]
+        return cls(values, column_labels)
 
     @classmethod
     def from_rows(cls, rows, column_labels):
@@ -106,7 +109,7 @@ class Table(collections.abc.MutableMapping):
     @classmethod
     def from_columns_dict(cls, columns):
         """Create a table from a mapping of column labels to column values."""
-        return cls(columns.values(), columns.keys())
+        return cls(list(columns.values()), columns.keys())
 
     @classmethod
     def read_table(cls, filepath_or_buffer, *args, **vargs):

--- a/docs/_autosummary/datascience.tables.Table.empty.rst
+++ b/docs/_autosummary/datascience.tables.Table.empty.rst
@@ -1,0 +1,6 @@
+datascience.tables.Table.empty
+==============================
+
+.. currentmodule:: datascience.tables
+
+.. automethod:: Table.empty

--- a/docs/_autosummary/datascience.tables.Table.from_columns_dict.rst
+++ b/docs/_autosummary/datascience.tables.Table.from_columns_dict.rst
@@ -1,0 +1,6 @@
+datascience.tables.Table.from_columns_dict
+==========================================
+
+.. currentmodule:: datascience.tables
+
+.. automethod:: Table.from_columns_dict

--- a/docs/tables.rst
+++ b/docs/tables.rst
@@ -40,8 +40,10 @@ Creation
     :toctree: _autosummary
 
     Table.__init__
+    Table.empty
     Table.from_rows
     Table.from_records
+    Table.from_columns_dict
     Table.read_table
 
 

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -395,11 +395,8 @@ def test_append_table(table):
 
 
 def test_append_different_table(table, u):
-    try:
+    with pytest.raises(KeyError):
         table.append(u)
-        assert False, 'KeyError expected'
-    except KeyError:
-        pass
 
 
 def test_append_different_order(table, table3):
@@ -451,6 +448,17 @@ def test_relabel_with_chars(table):
 ##########
 
 
+def test_empty():
+    t = Table.empty(['letter', 'count', 'points'])
+    assert_equal(t, """
+    letter | count | points
+    """)
+
+def test_empty_without_labels():
+    t = Table.empty()
+    assert_equal(t, '')
+
+
 def test_from_rows():
     letters = [('a', 9, 1), ('b', 3, 2), ('c', 3, 2), ('z', 1, 10)]
     t = Table.from_rows(letters, ['letter', 'count', 'points'])
@@ -483,6 +491,22 @@ def test_from_records():
         },
     ]
     t = Table.from_records(letters)
+    assert_equal(t.select(['letter', 'count', 'points']), """
+    letter | count | points
+    a      | 9     | 1
+    b      | 3     | 2
+    c      | 3     | 2
+    z      | 1     | 10
+    """)
+
+
+def test_from_columns_dict():
+    columns_dict = {
+        'letter': ['a', 'b', 'c', 'z'],
+        'count': [9, 3, 3, 1],
+        'points': [1, 2, 2, 10]
+    }
+    t = Table.from_columns_dict(columns_dict)
     assert_equal(t.select(['letter', 'count', 'points']), """
     letter | count | points
     a      | 9     | 1


### PR DESCRIPTION
This resolves #88.

The documentation for Table.__init__ has been simplified quite a bit by extracting the use case of initializing a table from a dict of column labels to column values into Table.from_columns_dict.

Also added a Table.empty method to create an empty table.