### PR TITLE
POC: Slice rows into Table

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1355,7 +1355,8 @@ class Table(collections.abc.MutableMapping):
 
         def __getitem__(self, i):
             if isinstance(i, slice):
-                return [self[j] for j in range(*i.indices(len(self)))]
+                return Table.from_rows([self[j] for j in range(*i.indices(len(self)))],
+                                       self._table.column_labels)
             labels = tuple(self._table.column_labels)
             if labels != self._labels:
                 self._labels = labels

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -86,6 +86,14 @@ def test_basic_rows(t):
         "Row(letter='c', count=3, points=2)")
 
 
+def test_rows_slice(t):
+    assert_equal(
+    t.rows[:2], """
+    letter | count | points
+    a      | 9     | 1
+    b      | 3     | 2""")
+
+
 def test_select(t):
     test = t.select(['points', 'count']).cumsum()
     assert_equal(test, """


### PR DESCRIPTION
This changes the semantics of array *slicing* to return a Table, being consistent with the notion of a Table consisting of multiple Rows.