### PR TITLE
Use __str__ as default __repr__

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -889,14 +889,10 @@ class Table(collections.abc.MutableMapping):
     # Exporting / Displaying #
     ##########################
 
-    def __repr__(self):
-        return '<{0}({1} cols, {2} rows): | {3} |>'.format(
-            type(self).__name__,
-            len(self),self.num_rows,
-            " | ".join(map(str, self.column_labels)))
-
     def __str__(self):
         return self.as_text(self.max_str_rows)
+
+    __repr__ = __str__
 
     def _repr_html_(self):
         return self.as_html(self.max_str_rows)


### PR DESCRIPTION
At the moment, a person needs to type `print(t)` every time you want to see what's going on inside a table, which gets rather tedious.

This patch proposes to set ``__repr__`` to `__str__`` so that you get a more useful representation by default.