### PR TITLE
Add conversion to/from NumPy structured arrays

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -949,10 +949,6 @@ class Table(collections.abc.MutableMapping):
             lines.append((0, '<p>... ({} rows omitted)</p'.format(omitted)))
         return '\n'.join(4 * indent * ' ' + text for indent, text in lines)
 
-    def matrix(self):
-        """Return a 2-D array with the contents of the table."""
-        return np.matrix(list(self._columns.values()))
-
     def index_by(self, column_or_label):
         """Return a dict keyed by values in a column that contains lists of
         rows corresponding to each value.
@@ -965,13 +961,30 @@ class Table(collections.abc.MutableMapping):
 
     @classmethod
     def from_df(cls, df):
-        """Convert a DataFrame into a Table."""
+        """Convert a Pandas DataFrame into a Table."""
         labels = df.columns
         return Table([df[label].values for label in labels], labels)
+
+    @classmethod
+    def from_array(cls, arr):
+        """Convert a structured NumPy array into a Table."""
+        return Table([arr[f] for f in arr.dtype.names],
+                     labels=arr.dtype.names)
 
     def to_df(self):
         """Convert the table to a Pandas DataFrame."""
         return pandas.DataFrame(self._columns)
+
+    def to_array(self):
+        """Convert the table to a NumPy array."""
+        dt = np.dtype(list(zip(self.column_labels,
+                               (c.dtype for c in self.columns))))
+        arr = np.empty_like(self.columns[0], dt)
+
+        for label in self.column_labels:
+            arr[label] = self[label]
+
+        return arr
 
     ##################
     # Visualizations #

--- a/docs/tables.rst
+++ b/docs/tables.rst
@@ -47,7 +47,8 @@ Creation
     Table.from_records
     Table.from_columns_dict
     Table.read_table
-
+    Table.from_df
+    Table.from_array
 
 Accessing values
 
@@ -105,8 +106,8 @@ Exporting / Displaying
     Table.show
     Table.as_text
     Table.as_html
-    Table.matrix
     Table.index_by
+    Table.to_array
     Table.to_df
 
 Visualizations

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -784,3 +784,12 @@ def test_df_roundtrip(table):
 
     for (c0, c1) in zip(t.columns, table.columns):
         assert_equal(c0, c1)
+
+def test_array_roundtrip(table):
+    arr = table.to_array()
+    assert isinstance(arr, np.ndarray)
+
+    t = Table.from_array(arr)
+
+    for (c0, c1) in zip(t.columns, table.columns):
+        assert_equal(c0, c1)


### PR DESCRIPTION
Note that this PR also removes ``t.matrix``, which returned a somewhat broken matrix object (matrices are not recommended for use, and in this case the column dtype was simply being taken from the first column, turning numbers into strings, etc.)