### PR TITLE
Fix bug in xticks for Table.plot()

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -1311,22 +1311,26 @@ class Table(collections.abc.MutableMapping):
         'alpha': 0.8,
     }
 
-    def plot(self, column_for_xticks=None, overlay=False, **vargs):
+    def plot(self, column_for_xticks, overlay=False, **vargs):
         """Plot contents as lines."""
         options = self.default_options.copy()
         options.update(vargs)
+
+        # Note that the labels here get incorrectly placed on the x-axis even
+        # though the labels describe the y-axis values.
+        # TODO(sam): Allow _visualize to accept options to put labels on both x
+        # and y axes.
         xticks, labels = self._split_by_column(column_for_xticks)
 
         def draw(axis, label, color):
             if xticks is None:
                 axis.plot(self[label], color=color, **options)
-            else :
+            else:
                 axis.plot(xticks, self[label], color=color, **options)
 
         def annotate(axis, ticks):
-            tick_labels = [ticks[int(l)] for l in axis.get_xticks() if l<len(ticks)]
-            axis.set_xticklabels(tick_labels, rotation='vertical')
-            return None
+            axis.set_xticklabels(axis.get_xticks(), rotation='vertical')
+
         self._visualize(labels, xticks, overlay, draw, annotate)
 
     def scatter(self, column_for_x, overlay=False, fit_line=False, **vargs):
@@ -1677,7 +1681,7 @@ class Table(collections.abc.MutableMapping):
 
     def boxplot(self, **vargs):
         """Plots a boxplot for the table.
-            
+
         Kwargs:
             vargs: Additional arguments that get passed into `plt.boxplot`.
                 See http://matplotlib.org/api/pyplot_api.html#matplotlib.pyplot.boxplot


### PR DESCRIPTION
Before, calling

    Table([np.arange(0, 10, .1), np.arange(0, 1, .01)], ['x', 'y']).plot('x')

Would show xticks of 0, 0.1, 0.2, etc. instead of 0, 2, 4, ...
This was beacuse we assumed that the horizontal axis values as passed in
the `ticks` variable were integers. Instead, we should just ask the axis
for the ticks it used to plot the data.

To test:

```python

a = Table([np.arange(0, 10, .1), np.arange(0, 1, .01)], ['x', 'y'])
a.plot('x')

b = Table([np.arange(0, 20, .1), np.arange(0, 2, .01)], ['x', 'y'])
b.plot('x')
```

![screenshot 2015-10-27 18 09 24](https://cloud.githubusercontent.com/assets/2468904/10777184/e1438c42-7cd5-11e5-845a-66d83ed7b0a0.png)

Note that the labels are still incorrect. I left it as a TODO for now but it'd be good to take care of this.