### PR TITLE
Changed Table.apply to take in multiple columns

### DIFF
--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -447,6 +447,21 @@ class Table(collections.abc.MutableMapping):
         """Returns an array where ``fn`` is applied to each set of elements
         by row from the specified columns in ``column_label``.
 
+        Args:
+            ``fn`` (function): The function to be applied to elements specified
+                by ``column_label``.
+            ``column_label`` (single string or list of strings): Names of
+                columns to be passed into function ``fn``. Length must match
+                number of elements ``fn`` takes.
+
+        Raises:
+            ``ValueError``: column name in ``column_label`` is not an existing
+                column in the table.
+
+        Returns:
+            A numpy array consisting of results of applying ``fn`` to elements
+            specified by ``column_label`` in each row.
+
         >>> letter = ['a', 'b', 'c', 'z']
         >>> count = [9, 3, 3, 1]
         >>> points = [1, 2, 2, 10]
@@ -459,10 +474,15 @@ class Table(collections.abc.MutableMapping):
         z      | 1     | 10
         >>> t.apply(lambda x, y: x * y, ['count', 'points'])
         array([ 9,  6,  6, 10])
+        >>> t.apply(lambda x: x - 1, 'points')
+        array([0, 1, 1, 9])
         """
         #return np.array([fn(v) for v in self[column_label]])
         if isinstance(column_label, str):
             column_label = [column_label]
+        for c in column_label:
+            if not (c in self.column_labels):
+                raise ValueError("{} is not an existing column in the table".format(c))
         return np.array([fn(*[self.take(i)[col][0] for col in column_label]) for i in range(self.num_rows)])
 
     ############

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -446,7 +446,10 @@ class Table(collections.abc.MutableMapping):
     def apply(self, fn, column_label):
         """Returns an array where fn is applied to each element
         of a specified column."""
-        return np.array([fn(v) for v in self[column_label]])
+        #return np.array([fn(v) for v in self[column_label]])
+        if isinstance(column_label, str):
+            column_label = [column_label]
+        return np.array([fn(*[self.take(i)[col] for col in column_label]) for i in range(len(self))])
 
     ############
     # Mutation #

--- a/datascience/tables.py
+++ b/datascience/tables.py
@@ -444,12 +444,26 @@ class Table(collections.abc.MutableMapping):
         return self.column_labels.index(column_label)
 
     def apply(self, fn, column_label):
-        """Returns an array where fn is applied to each element
-        of a specified column."""
+        """Returns an array where ``fn`` is applied to each set of elements
+        by row from the specified columns in ``column_label``.
+
+        >>> letter = ['a', 'b', 'c', 'z']
+        >>> count = [9, 3, 3, 1]
+        >>> points = [1, 2, 2, 10]
+        >>> t = Table([letter, count, points], ['letter', 'count', 'points'])
+        >>> t
+        letter | count | points
+        a      | 9     | 1
+        b      | 3     | 2
+        c      | 3     | 2
+        z      | 1     | 10
+        >>> t.apply(lambda x, y: x * y, ['count', 'points'])
+        array([ 9,  6,  6, 10])
+        """
         #return np.array([fn(v) for v in self[column_label]])
         if isinstance(column_label, str):
             column_label = [column_label]
-        return np.array([fn(*[self.take(i)[col] for col in column_label]) for i in range(len(self))])
+        return np.array([fn(*[self.take(i)[col][0] for col in column_label]) for i in range(self.num_rows)])
 
     ############
     # Mutation #

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ class PyTest(TestCommand):
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
 
     def run_tests(self):
         # import here, cause outside the eggs aren't loaded

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -363,6 +363,10 @@ def test_pivot_sum(t):
     True  | 1        | 2        | 0
     """)
 
+def test_apply(t):
+    t = t.copy()
+    assert_array_equal(t.apply(lambda x, y: x * y, ['count', 'points']), np.array([9, 6, 6, 10]))
+
 
 ########
 # Init #

--- a/tests/test_tables.py
+++ b/tests/test_tables.py
@@ -366,6 +366,9 @@ def test_pivot_sum(t):
 def test_apply(t):
     t = t.copy()
     assert_array_equal(t.apply(lambda x, y: x * y, ['count', 'points']), np.array([9, 6, 6, 10]))
+    assert_array_equal(t.apply(lambda x: x * x, 'points'), np.array([1, 4, 4, 100]))
+    with(pytest.raises(ValueError)):
+        t.apply(lambda x, y: x + y, ['count', 'score'])
 
 
 ########


### PR DESCRIPTION
Before, `Table.apply` could only apply a function with one argument to a single column in the table.

With this PR, we add the ability for `Table.apply` to take in an array of column names. See #130 