### PR TITLE
Install packages through conda instead of pip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,14 +5,33 @@ env:
   - GH_REPO: github.com/dsten/datascience.git
   - secure: "Ndq+rOhIGAOSb1wRUCayt0TjGGikJrZOOkS1b4Qi1qFyDzrJdWy80B6fd6ZslRWNAg1YKuvj2nbCOlaXL4gC4uXjZO8ag7tRnUCW8aCp9qJtVxLVGf43Yk+tKaTdPajgmBAEw785Ua0LmTrZRTvUQzybPd4BFQVnLQ9CQ7N0KFT0COtCLC5SJaBy3/sclodaDVv2zGv/WzQPsqtsyDqi5emz43WA8EsjieSNh9rbegY5i9TijjSyt4+sR9YTSakqR6/7vvDdhLZvPkbzAJNlvy1v1FkDNtv3QKHV05Nj17UDyXeF/gs3FmkioiZdtxswF9YZBAAXuc3Lo/fOQyBjS5HPPylSkq2gBVAWSRwcSKdz0CTO4Re2YKrFigWpbm/zJzT/O+8vRrYKoejyqNweO7gRwlumVPrmyUph0wvN8XTvm01np6ZUHMgaCLS2kKLjr8fZ9l+aah3EubGx5Qp2wPAx+IC2rqLjjkibd41g3zG7DGR+r9HwW20K4VjbptTHKTHICi6rvq9HiLqBEKH6Cmv+hF4h5rwH71apcZzFaxGt/KYEsX11T1BalA0FwVn8pKZSacsh8jNMnkWgv+5G5dqwocURKUBY4x1VoCXqbvQ8mPjX88ookr3hbvpxXwkwAltGMo3H8Y7a5JcGxU4w/NXm6VSRxkukHrLtnKa8kNQ="
 
-sudo: required
+sudo: false
 
 python:
   - "3.4.2"
 
+cache:
+  apt: true
+  directories:
+    - $HOME/miniconda
+
+addons:
+  apt:
+    packages:
+    - libatlas-dev
+    - libatlas-base-dev
+    - liblapack-dev
+    - gfortran
+
+before_install:
+  - wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+  - chmod +x miniconda.sh
+  - ./miniconda.sh -b -p $HOME/miniconda
+  - export PATH=/home/travis/miniconda/bin:$PATH
+  - conda update --yes conda
+
 install:
-  - sudo apt-get install gfortran libblas-dev liblapack-dev
-  - pip install pip --upgrade
+  - conda install --yes python=$TRAVIS_PYTHON_VERSION pip numpy scipy matplotlib pandas IPython
   # TODO(sam): Add --upgrade flag when it works again
   - python3 setup.py install
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,2 @@
 folium==0.1.5
 sphinx==1.3.1
-numpy==1.10.1
-scipy==0.16.1
-matplotlib==1.5.0
-pandas==0.17.1
-IPython==3.2.1

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,6 @@ class PyTest(TestCommand):
 
     def finalize_options(self):
         TestCommand.finalize_options(self)
-        self.test_args = []
-        self.test_suite = True
 
     def run_tests(self):
         # import here, cause outside the eggs aren't loaded


### PR DESCRIPTION
This commit resolves the pain we had with needing scipy in the
datascience package. Travis has a lot of problems installing it,
apparently.

Following the suggestions at http://lmjohns3.com/2015/06/using-travis-ci-with-miniconda-scipy-and-nose.html,
I install Miniconda and then install the necessary packages through
conda instead of pip.

This allows the packages to be easily installed and it looks like Travis
can cache the installed packages for even faster build times.

Build times went from ~20 minutes to ~3 minutes. Right now it looks like
caching isn't working properly so that can probably be cut down even more.

Resolves #152
Resolves #157
